### PR TITLE
feat(Conf): Modify min cd age for reset & refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Current features:
 
 - **Health/mana reset**: when duel starts it sets the health/mana of the player to the MAX, when the duel ends it restores the health/mana values that the player had before the duel
 - **Cooldown reset**: when duel starts it resets the player cooldowns
+- **Cooldown age**: sets the required age of a cooldown to be reset in order to prevent the feature from being abused
 
 
 ## Requirements

--- a/conf/duelreset.conf.dist
+++ b/conf/duelreset.conf.dist
@@ -1,16 +1,23 @@
 [worldserver]
 
 #
-#    DuelResetCooldowns
+#    DuelReset.CooldownEnable
 #        Description: Reset all cooldowns before duel starts and restore them when duel ends.
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
 
-DuelResetCooldowns = 1
+DuelReset.CooldownEnable = 1
 
-#    DuelResetHealthMana
+#    DuelReset.HealthManaEnable
 #        Description: Reset health and mana before duel starts and restore them when duel ends.
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
 
-DuelResetHealthMana = 1
+DuelReset.HealthManaEnable = 1
+
+#    DuelReset.CooldownAge
+#        Description: Required time of a cooldown passed for it to be reset. Measured in seconds since the cooldown started.
+#        Default:     30  - (Enabled)
+#                     0  - (Disabled)
+
+DuelReset.CooldownAge = 30

--- a/src/DuelReset.cpp
+++ b/src/DuelReset.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "DuelReset.h"
+#include "Config.h"
 
 DuelReset* DuelReset::instance()
 {
@@ -55,9 +56,9 @@ void DuelReset::ResetSpellCooldowns(Player* player, bool onStartDuel)
             && totalCooldown < 10 * MINUTE * IN_MILLISECONDS
             && categoryCooldown < 10 * MINUTE * IN_MILLISECONDS
             && remainingCooldown < 10 * MINUTE * IN_MILLISECONDS
-            && (onStartDuel ? (totalCooldown - remainingCooldown) > (MINUTE / 2) * IN_MILLISECONDS : true)
-            && (onStartDuel ? (categoryCooldown - remainingCooldown) > (MINUTE / 2) * IN_MILLISECONDS : true)
-                )
+            && (onStartDuel ? (totalCooldown - remainingCooldown) > CooldownAge * IN_MILLISECONDS : true)
+            && (onStartDuel ? (categoryCooldown - remainingCooldown) > CooldownAge * IN_MILLISECONDS : true)
+            )
             player->RemoveSpellCooldown(itr->first, true);
     }
 
@@ -156,4 +157,26 @@ void DuelReset::RestoreManaAfterDuel(Player* player) {
 
     player->SetPower(POWER_MANA, savedPlayerMana->second);
     m_manaBeforeDuel.erase(player);
+}
+
+void DuelReset::LoadConfig()
+{
+    ResetCdEnabled = sConfigMgr->GetBoolDefault("DuelReset.CooldownEnable", true);
+    ResetHealthEnabled = sConfigMgr->GetBoolDefault("DuelReset.HealthManaEnable", true);
+    CooldownAge = uint32(sConfigMgr->GetIntDefault("DuelReset.CooldownAge", 30));
+}
+
+bool DuelReset::GetCooldownEnabled()
+{
+    return ResetCdEnabled;
+}
+
+bool DuelReset::GetHealthEnabled()
+{
+    return ResetHealthEnabled;
+}
+
+uint32 DuelReset::GetCooldownAge()
+{
+    return CooldownAge;
 }

--- a/src/DuelReset.h
+++ b/src/DuelReset.h
@@ -12,6 +12,10 @@ class DuelReset
 public:
     static DuelReset* instance();
 
+    bool ResetCdEnabled;
+    bool ResetHealthEnabled;
+    uint64 CooldownAge;
+
     void ResetSpellCooldowns(Player* player, bool onStartDuel);
     void SaveCooldownStateBeforeDuel(Player* player);
     void RestoreCooldownStateAfterDuel(Player* player);
@@ -20,6 +24,12 @@ public:
     void SaveManaBeforeDuel(Player* player);
     void RestoreHealthAfterDuel(Player* player);
     void RestoreManaAfterDuel(Player* player);
+
+    void LoadConfig();
+
+    bool GetCooldownEnabled();
+    bool GetHealthEnabled();
+    uint32 GetCooldownAge();
 
 private:
     typedef std::unordered_map<Player*, SpellCooldowns> PlayersCooldownMap;

--- a/src/DuelReset_scripts.cpp
+++ b/src/DuelReset_scripts.cpp
@@ -24,6 +24,15 @@
 #include "Config.h"
 #include "DuelReset.h"
 
+class DuelResetBeforeConfigLoad : public WorldScript {
+public:
+    DuelResetBeforeConfigLoad() : WorldScript("DuelResetBeforeConfigLoad") { }
+
+    void OnBeforeConfigLoad(bool /*reload*/) override {
+        sDuelReset->LoadConfig();
+    }
+};
+
 class DuelResetScript : public PlayerScript {
 public:
     DuelResetScript() : PlayerScript("DuelResetScript") {}
@@ -31,7 +40,7 @@ public:
     // Called when a duel starts (after 3s countdown)
     void OnDuelStart(Player *player1, Player *player2) override {
         // Cooldowns reset
-        if (sConfigMgr->GetBoolDefault("DuelResetCooldowns", true)) {
+        if (sDuelReset->GetCooldownEnabled()) {
             sDuelReset->SaveCooldownStateBeforeDuel(player1);
             sDuelReset->SaveCooldownStateBeforeDuel(player2);
 
@@ -40,7 +49,7 @@ public:
         }
 
         // Health and mana reset
-        if (sConfigMgr->GetBoolDefault("DuelResetHealthMana", true)) {
+        if (sDuelReset->GetHealthEnabled()) {
             sDuelReset->SaveHealthBeforeDuel(player1);
             if (player1->getPowerType() == POWER_MANA || player1->getClass() == CLASS_DRUID) {
                 sDuelReset->SaveManaBeforeDuel(player1);
@@ -60,7 +69,7 @@ public:
         // do not reset anything if DUEL_INTERRUPTED or DUEL_FLED
         if (type == DUEL_WON) {
             // Cooldown restore
-            if (sConfigMgr->GetBoolDefault("DuelResetCooldowns", true)) {
+            if (sDuelReset->GetCooldownEnabled()) {
                 sDuelReset->ResetSpellCooldowns(winner, false);
                 sDuelReset->ResetSpellCooldowns(loser, false);
 
@@ -69,7 +78,7 @@ public:
             }
 
             // Health and mana restore
-            if (sConfigMgr->GetBoolDefault("DuelResetHealthMana", true)) {
+            if (sDuelReset->GetHealthEnabled()) {
                 sDuelReset->RestoreHealthAfterDuel(winner);
                 sDuelReset->RestoreHealthAfterDuel(loser);
 
@@ -87,5 +96,6 @@ public:
 
 void AddSC_DuelReset()
 {
+    new DuelResetBeforeConfigLoad();
     new DuelResetScript();
 }


### PR DESCRIPTION
## Changes Proposed:
- Implements the suggested feature to set the age required for spells to be reset within the config file
- Slight refactoring of config variables

## How to Test the Changes:
- Set a time in seconds in the config file
- Start duel with cooldowns of different age
- Repeat with various times