### PR TITLE
feat(Conf): Specify allowed zones/areas for reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current features:
 
 - **Health/mana reset**: when duel starts it sets the health/mana of the player to the MAX, when the duel ends it restores the health/mana values that the player had before the duel
 - **Cooldown reset**: when duel starts it resets the player cooldowns
-
+- **Reset zones/areas**: specify the zones and areas where the resets actually apply
 
 ## Requirements
 

--- a/conf/duelreset.conf.dist
+++ b/conf/duelreset.conf.dist
@@ -1,16 +1,16 @@
 [worldserver]
 
 #
-#    DuelResetCooldowns
+#    DuelReset.Cooldowns
 #        Description: Reset all cooldowns before duel starts and restore them when duel ends.
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
 
-DuelResetCooldowns = 1
+DuelReset.Cooldowns = 1
 
-#    DuelResetHealthMana
+#    DuelReset.HealthMana
 #        Description: Reset health and mana before duel starts and restore them when duel ends.
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
 
-DuelResetHealthMana = 1
+DuelReset.HealthMana = 1

--- a/conf/duelreset.conf.dist
+++ b/conf/duelreset.conf.dist
@@ -14,3 +14,26 @@ DuelReset.Cooldowns = 1
 #                     0  - (Disabled)
 
 DuelReset.HealthMana = 1
+
+#    DuelReset.Zones
+#        Description: Whitelist of ZoneIDs seperated by Semicolons (;) where the reset for cooldowns and health/mana is enabled.
+#                     If Zones is set to any, the set Areas do not matter. The reset will always be applied.
+#                     If Zones is set to none, only the set Areas matter.
+#
+#        Examples:    "876;3817" - (GM Island;Testing)
+#                     "0" - (none)
+#                     ""  - (any)
+#        Default:     "0" - (none)
+
+DuelReset.Zones = "0"
+
+#    DuelReset.Areas
+#        Description: Whitelist of AreaIDs seperated by Semicolons (;) where the reset for cooldowns and health/mana is enabled.
+#                     If Areas is set to any or none, only the set Zones matter.
+#
+#        Examples:    "85;1" - (Tirisfal Glades;Dun Morogh)
+#                     "0" - (none)
+#                     ""  - (any)
+#        Default:     "12;14;809" - (Elwynn Forest;Durotar;Gates of Ironforge)
+
+DuelReset.Areas = "12;14;809"

--- a/src/DuelReset.cpp
+++ b/src/DuelReset.cpp
@@ -157,3 +157,19 @@ void DuelReset::RestoreManaAfterDuel(Player* player) {
     player->SetPower(POWER_MANA, savedPlayerMana->second);
     m_manaBeforeDuel.erase(player);
 }
+
+void DuelReset::LoadConfig(bool /*reload*/)
+{
+    m_enableCooldowns = sConfigMgr->GetBoolDefault("DuelReset.Cooldowns", true);
+    m_enableHealth = sConfigMgr->GetBoolDefault("DuelReset.HealthMana", true);
+}
+
+bool DuelReset::GetResetCooldownsEnabled() const
+{
+    return m_enableCooldowns;
+}
+
+bool DuelReset::GetResetHealthEnabled() const
+{
+    return m_enableHealth;
+}

--- a/src/DuelReset.cpp
+++ b/src/DuelReset.cpp
@@ -162,6 +162,31 @@ void DuelReset::LoadConfig(bool /*reload*/)
 {
     m_enableCooldowns = sConfigMgr->GetBoolDefault("DuelReset.Cooldowns", true);
     m_enableHealth = sConfigMgr->GetBoolDefault("DuelReset.HealthMana", true);
+
+    FillWhitelist(sConfigMgr->GetStringDefault("DuelReset.Zones", "0"), m_zoneWhitelist);
+    FillWhitelist(sConfigMgr->GetStringDefault("DuelReset.Areas", "12;14;809"), m_areaWhitelist);
+}
+
+void DuelReset::FillWhitelist(std::string zonesAreas, std::vector<uint32> &whitelist)
+{
+    whitelist.clear();
+
+    if (zonesAreas.empty())
+        return;
+
+    std::string zone;
+    std::istringstream zoneStream(zonesAreas);
+    while (std::getline(zoneStream, zone, ';'))
+    {
+        whitelist.push_back(stoi(zone));
+    }
+}
+
+bool DuelReset::IsAllowedInArea(Player* player) const
+{
+    return (std::find(m_zoneWhitelist.begin(), m_zoneWhitelist.end(), player->GetZoneId()) != m_zoneWhitelist.end())
+        || (std::find(m_areaWhitelist.begin(), m_areaWhitelist.end(), player->GetAreaId()) != m_areaWhitelist.end())
+        || m_zoneWhitelist.empty();
 }
 
 bool DuelReset::GetResetCooldownsEnabled() const
@@ -172,4 +197,14 @@ bool DuelReset::GetResetCooldownsEnabled() const
 bool DuelReset::GetResetHealthEnabled() const
 {
     return m_enableHealth;
+}
+
+std::vector<uint32> DuelReset::GetZoneWhitelist() const
+{
+    return m_zoneWhitelist;
+}
+
+std::vector<uint32> DuelReset::GetAreaWhitelist() const
+{
+    return m_areaWhitelist;
 }

--- a/src/DuelReset.cpp
+++ b/src/DuelReset.cpp
@@ -85,6 +85,8 @@ void DuelReset::RestoreCooldownStateAfterDuel(Player* player)
     if (savedDuelCooldownsMap == m_spellCooldownsBeforeDuel.end())
         return;
 
+    sDuelReset->ResetSpellCooldowns(player, false);
+
     SpellCooldowns playerSavedDuelCooldowns = savedDuelCooldownsMap->second;
     uint32 curMSTime = World::GetGameTimeMS();
     uint32 infTime = curMSTime + player->infinityCooldownDelayCheck;

--- a/src/DuelReset.h
+++ b/src/DuelReset.h
@@ -14,6 +14,7 @@ public:
     static DuelReset* instance();
 
     void LoadConfig(bool reload);
+    void FillWhitelist(std::string zonesAreas, std::vector<uint32> &whitelist);
 
     void ResetSpellCooldowns(Player* player, bool onStartDuel);
     void SaveCooldownStateBeforeDuel(Player* player);
@@ -24,12 +25,17 @@ public:
     void RestoreHealthAfterDuel(Player* player);
     void RestoreManaAfterDuel(Player* player);
 
+    bool IsAllowedInArea(Player* player) const;
     bool GetResetCooldownsEnabled() const;
     bool GetResetHealthEnabled() const;
+    std::vector<uint32> GetZoneWhitelist() const;
+    std::vector<uint32> GetAreaWhitelist() const;
 private:
     // Config values
     bool m_enableCooldowns;
     bool m_enableHealth;
+    std::vector<uint32> m_zoneWhitelist;
+    std::vector<uint32> m_areaWhitelist;
 
     // Player value maps
     typedef std::unordered_map<Player*, SpellCooldowns> PlayersCooldownMap;

--- a/src/DuelReset.h
+++ b/src/DuelReset.h
@@ -5,12 +5,15 @@
 #include "Player.h"
 #include "Pet.h"
 #include "SpellInfo.h"
+#include "Config.h"
 #include <unordered_map>
 
 class DuelReset
 {
 public:
     static DuelReset* instance();
+
+    void LoadConfig(bool reload);
 
     void ResetSpellCooldowns(Player* player, bool onStartDuel);
     void SaveCooldownStateBeforeDuel(Player* player);
@@ -21,7 +24,14 @@ public:
     void RestoreHealthAfterDuel(Player* player);
     void RestoreManaAfterDuel(Player* player);
 
+    bool GetResetCooldownsEnabled() const;
+    bool GetResetHealthEnabled() const;
 private:
+    // Config values
+    bool m_enableCooldowns;
+    bool m_enableHealth;
+
+    // Player value maps
     typedef std::unordered_map<Player*, SpellCooldowns> PlayersCooldownMap;
     typedef std::unordered_map<Player*, uint32> PlayersHealthMap;
     typedef std::unordered_map<Player*, uint32> PlayersManaMap;

--- a/src/DuelReset_scripts.cpp
+++ b/src/DuelReset_scripts.cpp
@@ -104,6 +104,6 @@ public:
 
 void AddSC_DuelReset()
 {
-    new DuelResetAfterConfigLoad;
+    new DuelResetAfterConfigLoad();
     new DuelResetScript();
 }

--- a/src/DuelReset_scripts.cpp
+++ b/src/DuelReset_scripts.cpp
@@ -76,18 +76,11 @@ public:
 
     // Called when a duel ends
     void OnDuelEnd(Player *winner, Player *loser, DuelCompleteType type) override {
-        // Check if Reset is allowed in area or zone
-        if (!sDuelReset->IsAllowedInArea(winner)) {
-            return;
-        }
-
+        // Checking zone here is not necessary and would open options or abuse
         // do not reset anything if DUEL_INTERRUPTED or DUEL_FLED
         if (type == DUEL_WON) {
             // Cooldown restore
             if (sDuelReset->GetResetCooldownsEnabled()) {
-                sDuelReset->ResetSpellCooldowns(winner, false);
-                sDuelReset->ResetSpellCooldowns(loser, false);
-
                 sDuelReset->RestoreCooldownStateAfterDuel(winner);
                 sDuelReset->RestoreCooldownStateAfterDuel(loser);
             }

--- a/src/DuelReset_scripts.cpp
+++ b/src/DuelReset_scripts.cpp
@@ -44,6 +44,11 @@ public:
 
     // Called when a duel starts (after 3s countdown)
     void OnDuelStart(Player *player1, Player *player2) override {
+        // Check if Reset is allowed in area or zone
+        if (!sDuelReset->IsAllowedInArea(player1)) {
+            return;
+        }
+
         // Cooldowns reset
         if (sDuelReset->GetResetCooldownsEnabled()) {
             sDuelReset->SaveCooldownStateBeforeDuel(player1);
@@ -71,6 +76,11 @@ public:
 
     // Called when a duel ends
     void OnDuelEnd(Player *winner, Player *loser, DuelCompleteType type) override {
+        // Check if Reset is allowed in area or zone
+        if (!sDuelReset->IsAllowedInArea(winner)) {
+            return;
+        }
+
         // do not reset anything if DUEL_INTERRUPTED or DUEL_FLED
         if (type == DUEL_WON) {
             // Cooldown restore

--- a/src/DuelReset_scripts.cpp
+++ b/src/DuelReset_scripts.cpp
@@ -21,8 +21,22 @@
 #include "Player.h"
 #include "Pet.h"
 #include "SpellInfo.h"
-#include "Config.h"
 #include "DuelReset.h"
+
+class DuelResetAfterConfigLoad : public WorldScript {
+public:
+    DuelResetAfterConfigLoad() : WorldScript("DuelResetAfterConfigLoad") { }
+
+    void OnAfterConfigLoad(bool reload) override
+    {
+        sDuelReset->LoadConfig(reload);
+    }
+
+    void OnStartup() override
+    {
+        sDuelReset->LoadConfig(false);
+    }
+};
 
 class DuelResetScript : public PlayerScript {
 public:
@@ -31,7 +45,7 @@ public:
     // Called when a duel starts (after 3s countdown)
     void OnDuelStart(Player *player1, Player *player2) override {
         // Cooldowns reset
-        if (sConfigMgr->GetBoolDefault("DuelResetCooldowns", true)) {
+        if (sDuelReset->GetResetCooldownsEnabled()) {
             sDuelReset->SaveCooldownStateBeforeDuel(player1);
             sDuelReset->SaveCooldownStateBeforeDuel(player2);
 
@@ -40,7 +54,7 @@ public:
         }
 
         // Health and mana reset
-        if (sConfigMgr->GetBoolDefault("DuelResetHealthMana", true)) {
+        if (sDuelReset->GetResetHealthEnabled()) {
             sDuelReset->SaveHealthBeforeDuel(player1);
             if (player1->getPowerType() == POWER_MANA || player1->getClass() == CLASS_DRUID) {
                 sDuelReset->SaveManaBeforeDuel(player1);
@@ -60,7 +74,7 @@ public:
         // do not reset anything if DUEL_INTERRUPTED or DUEL_FLED
         if (type == DUEL_WON) {
             // Cooldown restore
-            if (sConfigMgr->GetBoolDefault("DuelResetCooldowns", true)) {
+            if (sDuelReset->GetResetCooldownsEnabled()) {
                 sDuelReset->ResetSpellCooldowns(winner, false);
                 sDuelReset->ResetSpellCooldowns(loser, false);
 
@@ -69,7 +83,7 @@ public:
             }
 
             // Health and mana restore
-            if (sConfigMgr->GetBoolDefault("DuelResetHealthMana", true)) {
+            if (sDuelReset->GetResetHealthEnabled()) {
                 sDuelReset->RestoreHealthAfterDuel(winner);
                 sDuelReset->RestoreHealthAfterDuel(loser);
 
@@ -87,5 +101,6 @@ public:
 
 void AddSC_DuelReset()
 {
+    new DuelResetAfterConfigLoad;
     new DuelResetScript();
 }


### PR DESCRIPTION
## Changes Proposed:
- Reworked configuration (required for proposed feature)
- Implements a functionality to set and restrict zones and areas where Health/Mana and Cooldowns are reset for dueling

## How to Test the Changes:
- Duel in areas where the reset is enabled and disabled

closes #16 